### PR TITLE
Added <py-repl> language syntax.

### DIFF
--- a/syntaxes/pyscript.tmLanguage.json
+++ b/syntaxes/pyscript.tmLanguage.json
@@ -74,6 +74,21 @@
 			]
 		},
 		{
+			"begin": "<py-repl>",
+			"captures": [
+				{
+					"name": "entity.name.tag.pyscript"
+				}
+			],
+			"end": "</py-repl>",
+			"name": "meta.tag.pyscript",
+			"patterns": [
+				{
+					"include": "source.python"
+				}
+			]
+		},
+		{
 			"include": "text.html.basic"
 		}
 	],


### PR DESCRIPTION
The <py-repl> element can also contain python code. This fix should add python syntax highlighting for <py-repl> content.

This has not been tested.